### PR TITLE
Tests sanitize (helper XML)

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -55,14 +55,23 @@ class TestHelpers(unittest.TestCase):
         for x in permitted_tags:
             T = TAG[x]
             s_tag = T().xml()
-            if x == "img/": # alt attribute is required 
+            if x == "img/": # alt or src attribute is required. src has to have a valid href
                 s_tag = T(_alt="empty").xml()
                 self.assertEqual(XML(s_tag, sanitize=True, permitted_tags=['img/'], allowed_attributes={'img': ['src', 'alt']}).xml(),
                     "<img alt=\"empty\" />")
-            elif x == "a": # It has to have a valid href
-                s_tag = T("link", _href="http://web2py.com/").xml()
+                s_tag = T(_src="/image.png").xml()
+                self.assertEqual(XML(s_tag, sanitize=True, permitted_tags=['img/'], allowed_attributes={'img': ['src', 'alt']}).xml(),
+                    "<img src=\"/image.png\" />")
+            elif x == "a": # It has to have a valid href or title or not tag empty 
+                s_tag = T("this is a link", _href="http://web2py.com/").xml()
                 self.assertEqual(XML(s_tag, sanitize=True, permitted_tags=['a'], allowed_attributes={'a': ['href', 'title']}).xml(),
-                    "<a href=\"http://web2py.com/\">link</a>")
+                    "<a href=\"http://web2py.com/\">this is a link</a>")
+                s_tag = T("without href", _title="this is a link?").xml()
+                self.assertEqual(XML(s_tag, sanitize=True, permitted_tags=['a'], allowed_attributes={'a': ['href', 'title']}).xml(),
+                    '<a title="this is a link?">without href</a>')
+                s_tag = T(_title="empty_tag").xml()
+                self.assertEqual(XML(s_tag, sanitize=True, permitted_tags=['a'], allowed_attributes={'a': ['href', 'title']}).xml(),
+                    '<a title="empty_tag"></a>')
             else:
                 self.assertEqual(XML(s_tag, sanitize=True, permitted_tags=permitted_tags, allowed_attributes=allowed_attributes).xml(), "<%s></%s>" %
                     (x, x) if not x[-1] == "/" else "<%s>" % (x.replace("/", " /")))                

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -104,10 +104,21 @@ class TestHelpers(unittest.TestCase):
         s_tag = TAG['div']("content", _style="{backgrond-color: red;}").xml()
         self.assertEqual(XML(s_tag, sanitize=True, permitted_tags=['div'], allowed_attributes={'div': ['style']}).xml(),
             '<div style="{backgrond-color: red;}">content</div>')
+        self.assertEqual(XML(TAG['a']("oh no!", _href="invalid_link").xml(), sanitize=True, permitted_tags=['a']).xml(), 'oh no!')
+        self.assertEqual(XML(TAG['div']("", _onclick="evil()").xml(), sanitize=True, permitted_tags=['div']).xml(), '<div></div>')
+
         # valid inside invalid
         s_tag = TAG['evil'](TAG['div']('valid'), _style="{backgrond-color: red;}").xml()
         self.assertEqual(XML(s_tag, sanitize=True, permitted_tags=['div'], allowed_attributes={'div': ['style']}).xml(),
             '&lt;evil&gt;<div>valid</div>&lt;/evil&gt;')
+        self.assertEqual(XML(TAG['a'](TAG['img/'](_src="/index.html"), _class="teste").xml(), sanitize=True, permitted_tags=['a', 'img/']).xml(), '<img src="/index.html" />')
+
+        # tags deleted even allowed
+        self.assertEqual(XML(TAG['img/']().xml(), sanitize=True, permitted_tags=['img']).xml(), "")
+        self.assertEqual(XML(TAG['img/'](_src="invalid_url").xml(), sanitize=True, permitted_tags=['img']).xml(), "")
+        self.assertEqual(XML(TAG['img/'](_class="teste").xml(), sanitize=True, permitted_tags=['img']).xml(), "")
+        self.assertEqual(XML(TAG['a'](_href="invalid_link").xml(), sanitize=True, permitted_tags=['a']).xml(), "")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There have been some different behaviors of the tool I use (bleach https://github.com/mozilla/bleach), for example, an html with: "<div> <img> </ div>" results in: "<div> </ div> ". It's not a problem, it's just different from bleach.