### PR TITLE
set convert_charrefs=False on Python3

### DIFF
--- a/yatl/sanitizer.py
+++ b/yatl/sanitizer.py
@@ -65,7 +65,10 @@ class XssCleaner(HTMLParser):
         strip_disallowed=False
     ):
 
-        HTMLParser.__init__(self)
+        if PY2:
+            HTMLParser.__init__(self)
+        else:
+            HTMLParser.__init__(self, convert_charrefs=False)
         self.result = ''
         self.open_tags = []
         self.permitted_tags = [i for i in permitted_tags if i[-1] != '/']


### PR DESCRIPTION
Since python 3.5, HTMLParser has defaulted to convert_charrefs=True, which means handle_charref and handle_entityref are never called, and all such entitys are converted.  This change ensures python2 and python3 behave in the same way, not converting &bull; to a bullet point, for example.