### PR TITLE
fixes issue #28, __setitem__ overriden

### DIFF
--- a/yatl/helpers.py
+++ b/yatl/helpers.py
@@ -404,7 +404,8 @@ class CAT(TAGGER):
         else:
             # attributes are set on all childrens
             for child in self.children:
-                child[key] = value
+                if isinstance(child, TAGGER):
+                    child[key] = value
 
     def xml(self):
         return "".join(


### PR DESCRIPTION
Please note the CAT.\_\_setitem\_\_ new behaviour, it is ok on passing "_disabled", might not on "_id" key.

@mdipierro  what should CAT.amend do?